### PR TITLE
Expand the two-character country codes into the full country name

### DIFF
--- a/js/countries.js
+++ b/js/countries.js
@@ -71,8 +71,10 @@ var legend = {
   ZA: "South Africa"
 }
 
-"use strict";
-
-var input = ["AU", "ZA", "PA"];
-
-console.log(input.map(code => legend[code]));
+for (var i = 0; i < countries.length; i++) {
+  listItem = legend[countries[i]];
+  const list = document.getElementById("countriesList");
+  const newItem = document.createElement("li");
+  newItem.innerText = listItem;
+  list.appendChild(newItem);
+}

--- a/js/main.js
+++ b/js/main.js
@@ -77,7 +77,7 @@ function search(trackID) {
           document.getElementById("label").innerHTML = "<strong>" + trackName + "</strong> is available in these countries:";
           const list = document.getElementById("list");
           for (var i = 0; i < markets.length; i++) {
-            listItem = legend[markets[i]];
+            let listItem = legend[markets[i]];
             const newItem = document.createElement("li");
             newItem.innerText = listItem;
             list.appendChild(newItem);

--- a/js/main.js
+++ b/js/main.js
@@ -60,9 +60,10 @@ function search(trackID) {
         xhr.setRequestHeader("Authorization", "Bearer " + token);
       },
       success: function success(data) {
-        var str = data.available_markets,
-          trackName = JSON.stringify(data.name),
-          markets = "<ul><li>" + str.join("</li><li>") + "</li></ul>";
+
+        var markets = data.available_markets,
+          trackName = JSON.stringify(data.name);
+
         if (str.toString() === "") {
           trackName = trackName.slice(1, trackName.length - 1);
           document.getElementById("label").innerHTML = "<strong>" + trackName + "</strong> song is available anywhere Spotify is available.";
@@ -70,10 +71,17 @@ function search(trackID) {
           document.getElementById("embed").innerHTML = embedPrefix + trackID + embedSuffix;
           document.getElementById("embed").classList.add("mt-3");
           document.getElementById("authAlert").style.display = "none";
+
         } else {
           trackName = trackName.slice(1, trackName.length - 1);
           document.getElementById("label").innerHTML = "<strong>" + trackName + "</strong> is available in these countries:";
-          document.getElementById("list").innerHTML = markets;
+          const list = document.getElementById("list");
+          for (var i = 0; i < markets.length; i++) {
+            listItem = legend[markets[i]];
+            const newItem = document.createElement("li");
+            newItem.innerText = listItem;
+            list.appendChild(newItem);
+          }
           document.getElementById("embed").innerHTML = embedPrefix + trackID + embedSuffix;
           document.getElementById("embed").classList.add("mt-3");
           document.getElementById("authAlert").style.display = "none";
@@ -81,4 +89,77 @@ function search(trackID) {
       }
     });
   }
+}
+
+var legend = {
+  // Asia
+  AU: "Australia",
+  JP: "Japan",
+  IL: "Israel",
+  HK: "Hong Kong",
+  ID: "Indonesia",
+  MY: "Malaysia",
+  NZ: "New Zealand",
+  PH: "Philippines",
+  SG: "Singapore",
+  TW: "Taiwan",
+  TH: "Thailand",
+  VN: "Vietnam",
+  // Europe
+  AD: "Andorra",
+  AT: "Austria",
+  BE: "Belgium",
+  BG: "Bulgaria",
+  CY: "Cyprus",
+  CZ: "Czech Republic",
+  DK: "Denmark",
+  EE: "Estonia",
+  FI: "Finland",
+  FR: "France",
+  DE: "Germany",
+  GR: "Greece",
+  HU: "Hungary",
+  IS: "Iceland",
+  IE: "Ireland",
+  IT: "Italy",
+  LV: "Latvia",
+  LI: "Liechtenstien",
+  LT: "Lithuania",
+  LU: "Luxembourg",
+  MT: "Malta",
+  MC: "Monaco",
+  NL: "Netherlands",
+  NO: "Norway",
+  PL: "Poland",
+  PT: "Portugal",
+  RO: "Romania",
+  SK: "Slovakia",
+  ES: "Spain",
+  SE: "Sweden",
+  CH: "Switzerland",
+  TR: "Turkey",
+  UK: "United Kingdom",
+  // Latin America and the Caribbean
+  AR: "Argentina",
+  BO: "Bolivia",
+  BR: "Brazil",
+  CL: "Chile",
+  CO: "Colombia",
+  CR: "Costa Rica",
+  DO: "Dominican Republic",
+  EC: "Ecuador",
+  SV: "El Savador",
+  GT: "Guatamala",
+  HN: "Honduras",
+  MX: "Mexico",
+  NI: "Nicaragua",
+  PA: "Panama",
+  PY: "Paraguy",
+  PE: "Peru",
+  UY: "Uruguay",
+  // North America
+  CA: "Canada",
+  US: "United States",
+  // Africa
+  ZA: "South Africa"
 }

--- a/js/main.js
+++ b/js/main.js
@@ -79,7 +79,7 @@ function search(trackID) {
           for (var i = 0; i < markets.length; i++) {
             let listItem = legend[markets[i]];
             const newItem = document.createElement("li");
-            newItem.innerText = listItem;
+            newItem.innerHTML = listItem + " <small class='text-muted'>" + markets[i] + "</small>";
             list.appendChild(newItem);
           }
           console.log("Successfully expanded country names.")

--- a/js/main.js
+++ b/js/main.js
@@ -82,6 +82,7 @@ function search(trackID) {
             newItem.innerText = listItem;
             list.appendChild(newItem);
           }
+          console.log("Successfully expanded country names.")
           document.getElementById("embed").innerHTML = embedPrefix + trackID + embedSuffix;
           document.getElementById("embed").classList.add("mt-3");
           document.getElementById("authAlert").style.display = "none";

--- a/js/main.js
+++ b/js/main.js
@@ -64,7 +64,7 @@ function search(trackID) {
         var markets = data.available_markets,
           trackName = JSON.stringify(data.name);
 
-        if (str.toString() === "") {
+        if (markets.toString() === "") {
           trackName = trackName.slice(1, trackName.length - 1);
           document.getElementById("label").innerHTML = "<strong>" + trackName + "</strong> song is available anywhere Spotify is available.";
           document.getElementById("list").outerHTML = "";


### PR DESCRIPTION
Right now, SCAC displays the results given through the API as the two-character country codes. Instead, it's pretty obvious that people would prefer to see the full country name instead of the codes. That's what this PR addresses.